### PR TITLE
Add missing comma in add-torrent

### DIFF
--- a/machines/add-torrent.js
+++ b/machines/add-torrent.js
@@ -59,7 +59,7 @@ module.exports = {
       password: inputs.password,
     }).execSync();
     var options = {
-      'torrent_file': inputs.torrentContents
+      'torrent_file': inputs.torrentContents,
       'download_dir': inputs.downloadDir || 0,
       'path': inputs.path || ''
     };


### PR DESCRIPTION
This PR simply adds a missing comma in add-torrent.js that prevented the machine from loading
