### PR TITLE
Added machines for start, stop and remove api methods

### DIFF
--- a/machines/remove-torrent.js
+++ b/machines/remove-torrent.js
@@ -1,0 +1,64 @@
+module.exports = {
+
+  friendlyName: 'Remove Torrent',
+
+  description: 'Remove the torrent specified by the hash parameter from the download list.',
+
+  cacheable: false,
+
+  sync: false,
+
+  inputs: {
+    host: {
+      example: 'localhost',
+      required: true
+    },
+    port: {
+      example: 26085,
+      required: true
+    },
+    username: {
+      example: 'admin',
+      required: true
+    },
+    password: {
+      example: '12345',
+      required: true
+    },
+    hash: {
+      example: '',
+      required: true
+    }
+  },
+
+  exits: {
+
+    success: {
+      variableName: 'result',
+      description: 'Done.',
+    },
+
+  },
+
+  fn: function (inputs, exits) {
+    var Machine = require('machine');
+    var createClient = Machine.build(require('./create-client'));
+    var client = createClient({
+      host: inputs.host,
+      port: inputs.port,
+      username: inputs.username,
+      password: inputs.password,
+    }).execSync();
+    var options = {
+      'hash': inputs.hash
+    };
+    client.call('remove', options, function (err, data) {
+      if (err) {
+        return exits.error(err);
+      }
+      return exits.success(data);
+    });
+
+  },
+
+};

--- a/machines/start-torrent.js
+++ b/machines/start-torrent.js
@@ -1,0 +1,64 @@
+module.exports = {
+
+  friendlyName: 'Start Torrent',
+
+  description: 'Start downloading the torrent specified by the hash parameter.',
+
+  cacheable: false,
+
+  sync: false,
+
+  inputs: {
+    host: {
+      example: 'localhost',
+      required: true
+    },
+    port: {
+      example: 26085,
+      required: true
+    },
+    username: {
+      example: 'admin',
+      required: true
+    },
+    password: {
+      example: '12345',
+      required: true
+    },
+    hash: {
+      example: '',
+      required: true
+    }
+  },
+
+  exits: {
+
+    success: {
+      variableName: 'result',
+      description: 'Done.',
+    },
+
+  },
+
+  fn: function (inputs, exits) {
+    var Machine = require('machine');
+    var createClient = Machine.build(require('./create-client'));
+    var client = createClient({
+      host: inputs.host,
+      port: inputs.port,
+      username: inputs.username,
+      password: inputs.password,
+    }).execSync();
+    var options = {
+      'hash': inputs.hash
+    };
+    client.call('start', options, function (err, data) {
+      if (err) {
+        return exits.error(err);
+      }
+      return exits.success(data);
+    });
+
+  },
+
+};

--- a/machines/stop-torrent.js
+++ b/machines/stop-torrent.js
@@ -1,0 +1,64 @@
+module.exports = {
+
+  friendlyName: 'Stop Torrent',
+
+  description: 'Stop downloading the torrent specified by the hash parameter.',
+
+  cacheable: false,
+
+  sync: false,
+
+  inputs: {
+    host: {
+      example: 'localhost',
+      required: true
+    },
+    port: {
+      example: 26085,
+      required: true
+    },
+    username: {
+      example: 'admin',
+      required: true
+    },
+    password: {
+      example: '12345',
+      required: true
+    },
+    hash: {
+      example: '',
+      required: true
+    }
+  },
+
+  exits: {
+
+    success: {
+      variableName: 'result',
+      description: 'Done.',
+    },
+    
+  },
+
+  fn: function (inputs, exits) {
+    var Machine = require('machine');
+    var createClient = Machine.build(require('./create-client'));
+    var client = createClient({
+      host: inputs.host,
+      port: inputs.port,
+      username: inputs.username,
+      password: inputs.password,
+    }).execSync();
+    var options = {
+      'hash': inputs.hash
+    };
+    client.call('stop', options, function (err, data) {
+      if (err) {
+        return exits.error(err);
+      }
+      return exits.success(data);
+    });
+
+  },
+
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "machinepack-utorrent",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Communicate with uTorrent client API to list and add torrents.",
   "scripts": {
     "test": "node ./node_modules/test-machinepack-mocha/bin/testmachinepack-mocha.js"
@@ -35,7 +35,10 @@
       "list-torrents",
       "get-torrent-details",
       "create-client",
-      "add-torrent-url"
+      "add-torrent-url",
+      "start-torrent",
+      "stop-torrent",
+      "remove-torrent"
     ]
   }
 }


### PR DESCRIPTION
The implementation is based on the existing add-torrent-url machine.
Implemented the APIs as described in [uTorrent API doc](http://help.utorrent.com/customer/en/portal/articles/1573952-actions---webapi)
Only parameter for all three of them is the hash.

Please let me know if I missed something. Thanks!
